### PR TITLE
fix issues encountered when parsing error_required errors

### DIFF
--- a/src/OpenApiValidation.php
+++ b/src/OpenApiValidation.php
@@ -561,7 +561,7 @@ class OpenApiValidation implements MiddlewareInterface
                 $err[$attr] = $value;
             }
             if ('error_required' == $err['code']) {
-                $err['name'] .= mb_strlen($err['name']) ? '.'.$err['missing'] : $err['missing'];
+                $err['name'] .= ($err['name'] && mb_strlen($err['name'])) ? '.'.array_shift($err['missing']) : array_shift($err['missing']);
                 unset($err['missing'],$err['value']);
             }
             if ('error_'.'$'.'schema' == $err['code']) {


### PR DESCRIPTION
- `$name` is `null` by default and can no longer be passed to `mb_strlen` in PHP 8.1: `Deprecated: mb_strlen(): Passing null to parameter #1 ($string) of type string is deprecated`. check the value is truthy before passing to method 

- `$err['missing']` is now an array not a string. getting the first value from it now